### PR TITLE
Replace PanelManager for WorkspaceManager

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,7 +13,7 @@ define(function (require, exports, module) {
         AppInit = brackets.getModule('utils/AppInit'),
         Resizer = brackets.getModule('utils/Resizer'),
         Commands = brackets.getModule('command/Commands'),
-        PanelManager = brackets.getModule('view/PanelManager'),
+        WorkspaceManager = brackets.getModule('view/WorkspaceManager'),
         EditorManager = brackets.getModule('editor/EditorManager'),
         ExtensionUtils = brackets.getModule('utils/ExtensionUtils'),
         CommandManager = brackets.getModule('command/CommandManager'),
@@ -333,7 +333,7 @@ define(function (require, exports, module) {
     AppInit.htmlReady(function () {
 
         var minHeight = 100;
-        PanelManager.createBottomPanel(EXTENSION_ID + '.panel', $(Mustache.render(PanelHTML, ExtensionStrings)), minHeight);
+        WorkspaceManager.createBottomPanel(EXTENSION_ID + '.panel', $(Mustache.render(PanelHTML, ExtensionStrings)), minHeight);
         $appPanel = $('#brackets-console-panel');
         $logContainer = $($appPanel.find('.table-container').first());
 


### PR DESCRIPTION
To update the extension with new API of Brackets and to avoid the
message log  "Use WorkspaceManager.createBottomPanel() instead of
PanelManager.createBottomPanel()."

https://github.com/adobe/brackets/blob/master/src/view/PanelManager.js
@deprecated PanelManager module provided for backwards compatibility.  Use WorkspaceManager instead. 
